### PR TITLE
Widescreen header footer fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ NextJS application for the dibbs landing page. This project builds into a static
 
 This site (currently just one page) is implemented with the NextJS framework. Pages were built using `@uswds/uswds` and `@trussworks/react-uswds`. The USWDS settings have been adjusted with the DIBBs design system palette.
 
-You will need `node v20+` installed.
-
 ## Local development
+
+You will need `node v20+` installed. To install app dependencies run command:
+
+`npm install`
 
 Start the application in watch mode and hot reload with command:
 

--- a/src/components/hero/hero.tsx
+++ b/src/components/hero/hero.tsx
@@ -9,7 +9,7 @@ const Hero: React.FC = () => {
         <h1 className="text-white font-family-heading desktop:grid-col-7 grid-col-12">
           Improve the way your jurisdiction collects, processes, and views public health data
         </h1>
-        <p className="text-thin desktop:grid-col-9 grid-col-12">
+        <p className="text-thin desktop:grid-col-10 grid-col-12">
           Turn your jurisdiction&apos;s data into meaningful intelligence that drives
           timely public health action using CDC&apos;s free, cloud-based products built from Data
           Integration Building Blocks, or DIBBs.

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,19 +24,16 @@ body {
 
 /* main content */
 .page-container {
-  //margin: 0 40px;
   margin: 0 auto;
   max-width: 350px;
   width: calc(100% - 80px);
 
   @media (width >= 40em) {
-    //margin: 0 140px;
     width: calc(100% - 280px);
     max-width: 744px;
   }
 
   @media (width >= 64em) {
-    // margin: 0 160px;
     width: calc(100% - 320px);
     max-width: 1120px;
   }
@@ -48,22 +45,34 @@ body {
 
 /* hero, subfooter*/
 .page-container--lg {
-  margin: 0 40px;
+  margin: 0 auto;
+  max-width: 350px;
+  width: calc(100% - 80px);
 
   @media (width >= 40em) {
-    margin: 0 90px;
+    width: calc(100% - 180px);
+    max-width: 844px;
   }
 
   @media (width >= 64em) {
-    margin: 0 120px;
+    width: calc(100% - 240px);
+    max-width: 1200px;
   }
 }
 
 /* header, footer*/
 .page-container--xl {
-  margin: 0 40px;
+  margin: 0 auto;
+  max-width: 350px;
+  width: calc(100% - 80px);
 
-  @media (width >= 40em) {
-    margin: 0 80px;
+   @media (width >= 40em) {
+    width: calc(100% - 160px);
+    max-width: 864px;
+  }
+
+  @media (width >= 64em) {
+    width: calc(100% - 160px);
+    max-width: 1280px;
   }
 }


### PR DESCRIPTION
Hero content needs to have a max width and be centered for widescreen view. This PR adds css to accommodate for it. Below is a screenshot of how page will look for widescreen.
![localhost_3000_ (2)](https://github.com/user-attachments/assets/99321df4-a21f-48ee-8542-5e4b53b8e563)
