### PR TITLE
Fixed element width

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -96,7 +96,7 @@ const Card: React.FC<CardProps> = ({
             <p className="grid-col-10 tablet:grid-col-12 desktop:grid-col-12 text-accent-cool text-medium text-italic">
               Access to this demo requires login credentials:
             </p>
-            <p className="grid-col-9 tablet:grid-col-12 desktop:grid-col-12 text-accent-cool text-medium">
+            <p className="grid-col-8 tablet:grid-col-12 desktop:grid-col-12 text-accent-cool text-medium">
               <span className="text-normal">Username: </span>
               <span className="text-semibold">demo</span>{" "}
               <span className="text-normal">Password: </span>


### PR DESCRIPTION
The credentials content is breaking into multiple lines for the mobile view. This PR adjusts the width of the element to prevent that from happening.