### PR TITLE
feat: add deploy to demo workflow trigger

### DIFF
--- a/.github/workflows/deploy_to_demo.yaml
+++ b/.github/workflows/deploy_to_demo.yaml
@@ -1,0 +1,34 @@
+name: Deploy to Demo
+run-name: Deploy ${{ inputs.version }} to Demo by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        type: string
+        description: "The service you want to deploy. dibbs-landing"
+        required: true
+        default: dibbs-landing
+      version:
+        type: string
+        description: "The version to deploy. Example: v2.6.0 or main"
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to AWS
+        run: |
+          repo_owner="skylight-hq" 
+          repo_name="dibbs-tf-envs"  
+          event_type="trigger-demo-deploy" 
+          service="${{ github.event.inputs.service }}"
+          version="${{ github.event.inputs.version }}"
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DIBBS_SKYLIGHT_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"service\": \"$service\"}}"


### PR DESCRIPTION
## Changes Proposed

- Added a new GitHub Actions workflow file (deploy_to_demo.yaml) to enable manual deployment to the demo environment.
- The workflow accepts inputs for the service name and version, and triggers a secondary GitHub Actions workflow in `dibbs-tf-env`

## Testing

Once this merges to main:
  - Manually trigger the workflow on GitHub.
  - Verify that the API call is correctly made with the appropriate payload.
  - Check the `dibbs-tf-envs` repo kicks off the appropriate job.